### PR TITLE
[PIR-1513] Database Query is not cancelled when hitting 'Cancel' duri…

### DIFF
--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/async/AsyncReportStatusListener.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/async/AsyncReportStatusListener.java
@@ -85,6 +85,11 @@ public class AsyncReportStatusListener implements IAsyncReportListener {
     }
   }
 
+  // [PIR-1513] This should be in the interface, but since this is a propoesed code fix for HotFix, this needs ENG to review and agree
+  public synchronized boolean isCanceled() {
+	    return AsyncExecutionStatus.CANCELED.equals( this.status );
+	  }
+
   @Override
   public synchronized void setErrorMessage( final String errorMessage ) {
     this.errorMessage = errorMessage;


### PR DESCRIPTION
…ng the run/build of an Interactive Report

This code is for HotFix the cancel query. The listener has info of status but did not have a way to ask if the report was cancelled. added this to simplify the question by lower level items.

NOTE: since this ListenerStatus is available via LocalThread, then any class within the correct Thread will be able to see the correct value for their execution.